### PR TITLE
Add cooking_time, steps, and ingredients to recipe model

### DIFF
--- a/lib/foodplan/recipe.ex
+++ b/lib/foodplan/recipe.ex
@@ -5,6 +5,9 @@ defmodule Foodplan.Recipe do
   schema "recipees" do
     field :name, :string
     field :category, :string
+    field :cooking_time, :integer
+    field :steps, :string
+    field :ingredients, :string
 
     timestamps(type: :utc_datetime)
   end
@@ -12,7 +15,7 @@ defmodule Foodplan.Recipe do
   @doc false
   def changeset(recipe, attrs) do
     recipe
-    |> cast(attrs, [:name, :category])
-    |> validate_required([:name, :category])
+    |> cast(attrs, [:name, :category, :cooking_time, :steps, :ingredients])
+    |> validate_required([:name, :category, :cooking_time, :steps, :ingredients])
   end
 end

--- a/priv/repo/migrations/20241118224855_add_cooking_time_steps_ingredients_to_recipees.exs
+++ b/priv/repo/migrations/20241118224855_add_cooking_time_steps_ingredients_to_recipees.exs
@@ -1,0 +1,11 @@
+defmodule Foodplan.Repo.Migrations.AddCookingTimeStepsIngredientsToRecipees do
+  use Ecto.Migration
+
+  def change do
+    alter table(:recipees) do
+      add :cooking_time, :integer
+      add :steps, :text
+      add :ingredients, :text
+    end
+  end
+end


### PR DESCRIPTION
Add new attributes to the recipe model and update the database structure.

* Add `cooking_time`, `steps`, and `ingredients` fields to the `Recipe` schema in `lib/foodplan/recipe.ex`.
* Update the `changeset` function in `lib/foodplan/recipe.ex` to cast and validate the new fields.
* Create a new migration file `priv/repo/migrations/20241118224855_add_cooking_time_steps_ingredients_to_recipees.exs` to add `cooking_time`, `steps`, and `ingredients` columns to the `recipees` table.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreuramos/foodplan/pull/1?shareId=d44e4702-0307-499e-ab94-cf22d4ad0b34).